### PR TITLE
Upgrade jackson to latest (2.9.7) to address security vulnerability:

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -18,7 +18,7 @@
     <slf4j.version>1.7.25</slf4j.version>
     <swagger-annotations-version>1.5.15</swagger-annotations-version>
     <spring-web-version>4.3.9.RELEASE</spring-web-version>
-    <jackson-version>2.8.9</jackson-version>
+    <jackson-version>2.9.7</jackson-version>
     <junit-version>4.12</junit-version>
     <truth.version>0.42</truth.version>
     <mockito.version>2.20.1</mockito.version>


### PR DESCRIPTION
https://github.com/ChainMonitor/blocwatch-java-sdk/issues/8